### PR TITLE
Fix by klimp: Fixed entity's default language determination while exporting

### DIFF
--- a/src/Exporter/ContentExporter.php
+++ b/src/Exporter/ContentExporter.php
@@ -41,7 +41,7 @@ class ContentExporter implements ContentExporterInterface {
 
     // Include translations to the normalized entity
     $yaml_parsed = Yaml::decode($normalized_entity);
-    $lang_default = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $lang_default = $entity->language()->getId();
     foreach ($entity->getTranslationLanguages() as $langcode => $language) {
       // Verify that it is not the default langcode.
       if ( $langcode != $lang_default ) {


### PR DESCRIPTION
_Problem:_ the module considers an entity's default language to be the same as the site's default language every time but, in fact, the entity's default language could be different.

_Example:_ a multilingual site has English as a default language but a particular block, let's say, in Czech with English translation. When exported the yml indicates Czech as a default language but also adds it to the translations which is wrong, no track of English translation in yml.