### PR TITLE
Fix by klimp: Fixed filenames with space handling while exporting to tar

### DIFF
--- a/src/Form/ContentExportTrait.php
+++ b/src/Form/ContentExportTrait.php
@@ -156,7 +156,7 @@ trait ContentExportTrait {
                   $destination = "{$serializer_context['content_sync_directory_files']}/{$scheme}/";
                   $destination = str_replace($scheme . '://', $destination, $uri);
                   $strip_path = str_replace('/files' , '', $serializer_context['content_sync_directory_files'] );
-                  $this->getArchiver()->addModify($destination, '', $strip_path);
+                  $this->getArchiver()->addModify([$destination], '', $strip_path);
                 }
               }
               if( $serializer_context['export_type'] == 'folder') {


### PR DESCRIPTION
**Problem:** Filenames with spaces cause an error while exporting to tar.

**Solution:** The first parameter could be either an array of filenames or a single string. I replaced it with an array of one string.

https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Archiver%21ArchiveTar.php/function/ArchiveTar%3A%3AaddModify/8.2.x